### PR TITLE
Bumped version number to correlate with tag and http://semver.org/ conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ As developers and designers we think in pixels and device families, so the
 ## How to Use It
 
 1. Install with [Bower](http://bower.io/ "BOWER: A package manager for the 
-web"): `bower install sass-mq`  
+web"): `bower install sass-mq --save-dev`  
    OR [Download _mq.scss](https://raw.github.com/guardian/sass-mq/master/_mq.scss)
    to your Sass project.
 2. Import the partial in your Sass files and override

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "queries",
     "media"
   ],
-  "version": "0.1.0",
+  "version": "1.0.0",
   "main": "_mq.scss",
   "author": "Guardian Media Group",
   "ignore": [


### PR DESCRIPTION
This PR does two simple things:

As per the [Bower.io](http://bower.io) _registering packages_ guidelines our repo needs to have proper git tags for each version we publish:

> Your package should use semver Git tags.

Therefore, I have setup the first tag [here](https://github.com/guardian/sass-mq/releases/tag/v1.0.0)

As per the [_semantic versioning_](http://semver.org/) guidelines if we're using the software in production then it should be at least v1.0.0:

> If your software is being used in production, it should probably already be 1.0.0. If you have a stable API on which users have come to depend, you should be 1.0.0. If you're worrying a lot about backwards compatibility, you should probably already be 1.0.0.
