### PR TITLE
Declare character encoding to prevent invalid US-ASCII character error

### DIFF
--- a/_mq.scss
+++ b/_mq.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 // To enable support for browsers that do not support @media queries,
 // (IE <= 8, Firefox <= 3, Opera <= 9) set $mq-responsive to false
 // Create a separate stylesheet served exclusively to these browsers,


### PR DESCRIPTION
Without `@charset UTF-8' Sass compiler will throw an error "Syntax error: Invalid US-ASCII character "\xE2".
Adding charset is the easest to prevent that error.  
