### PR TITLE
Make $mq-show-breakpoints fixed so always shown in viewport

### DIFF
--- a/_mq.scss
+++ b/_mq.scss
@@ -147,7 +147,7 @@ $mq-show-breakpoints: () !default;
         color: #C09853;
         font: small-caption;
         padding: 3px 6px;
-        position: absolute;
+        position: fixed;
         right: 0;
         top: 0;
         z-index: 100;


### PR DESCRIPTION
Relieving RSI from continually having to scroll up to see what the current breakpoint is.

![](http://media.giphy.com/media/SHnQlab7xbrFe/giphy.gif)
