### PR TITLE
Merge duplicate `ignore` attribute in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
   "main": "_mq.scss",
   "author": "Guardian Media Group",
   "ignore": [
+    "test",
     "**/.*"
   ],
   "licenses": [
@@ -24,8 +25,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/sass-mq"
-  },
-  "ignore": [
-    "test"
-  ]
+  }
 }


### PR DESCRIPTION
Hi!

Nothing big, there was a duplicate `ignore` attribute in the `bower.json` file.

Thanks for sharing this awesome tool!

Cheers,
Thomas.
