### PR TITLE
update description

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Stylesheets") mixin that helps you compose media queries in an elegant
 way. It was developed in house at [the Guardian](http://www.theguardian.com/uk?view=mobile),
 and is now also in use at BBC Sport and the Financial Times…_
 
-- keywords or `px`/`em` values are compiled to `em`-based queries
-- fallbacks are provided for older browsers (see [Mobile-first Responsive Web Design and IE8](http://www.theguardian.com/info/developer-blog/2013/oct/14/mobile-first-responsive-ie8) on the Guardian's developer blog).
+- compiles keywords and `px`/`em` values to `em`-based queries ([a good thing](http://css-tricks.com/zooming-squishes))
+- provides fallbacks for older browsers (see [Mobile-first Responsive Web Design and IE8](http://www.theguardian.com/info/developer-blog/2013/oct/14/mobile-first-responsive-ie8) on the Guardian's developer blog).
 
 ## How to Use It
 


### PR DESCRIPTION
readme now reads:

_`mq()` is a [Sass](http://sass-lang.com/) mixin that helps you compose media queries in an elegant way. It was developed in house at [the Guardian](http://www.theguardian.com/uk?view=mobile), and is now also in use at BBC Sport and the Financial Times…_
- keywords or `px`/`em` values are compiled to `em`-based queries
- fallbacks are provided for older browsers (see [Mobile-first Responsive Web Design and IE8](http://www.theguardian.com/info/developer-blog/2013/oct/14/mobile-first-responsive-ie8) on the Guardian's developer blog).
