### PR TITLE
npm support - Fixes #22 and #51

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: ruby
-script:
-  - "./test.sh"
-
+sudo: false
 before_install:
   - gem install sass
-  - "npm install node-sass bower -g && bower install sass-mq"
+  - "npm install -g bower && bower install sass-mq"
+  - npm install node-sass --save-dev
+after_install:
+  - sass test/test.scss test/test.css --load-path 'bower_components/sass-mq' --load-path './'  --sourcemap=none
+  - node-sass test/test.scss test/test.css --include-path 'bower_components/sass-mq' --include-path './' --sourcemap=none
+  - node test/eyeglass-test.js

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ and is now also in use at BBC Sport and the Financial Times…_
 
 1. Install with [Bower](http://bower.io/ "BOWER: A package manager for the web"):
    `bower install sass-mq --save`
+   OR Install with [npm](https://www.npmjs.com/): `npm install "sass-mq/sass-mq" --save`
    OR [Download _mq.scss](https://raw.github.com/sass-mq/sass-mq/master/_mq.scss)
    to your Sass project.
 2. Import the partial in your Sass files and override default settings

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "sass-mq",
+  "description": "mq() is a Sass mixin that helps manipulating media queries in an elegant way.",
+  "keywords": [
+    "responsive",
+    "sass",
+    "rwd",
+    "mediaquery",
+    "query",
+    "queries",
+    "media"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sass-mq/sass-mq.git"
+  },
+  "author": "Guardian Media Group and contributors",
+  "license": "MIT",
+  "main": "_mq.scss",
+  "style": "_mq.scss",
+  "files": [
+    "_mq.scss",
+    "show-breakpoints.gif",
+    "LICENSE.md",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "sass-mq",
   "description": "mq() is a Sass mixin that helps manipulating media queries in an elegant way.",
+  "version": "3.1.2",
   "keywords": [
     "responsive",
     "sass",
@@ -10,21 +11,27 @@
     "queries",
     "media"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/sass-mq/sass-mq.git"
-  },
-  "author": "Guardian Media Group and contributors",
-  "license": "MIT",
-  "main": "_mq.scss",
-  "style": "_mq.scss",
-  "files": [
-    "_mq.scss",
-    "show-breakpoints.gif",
-    "LICENSE.md",
-    "README.md"
+  "contributors": [
+    {
+      "name": "Guardian Media Group and Contributors.",
+      "email": "",
+      "web": ""
+    }
   ],
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  }
+  "bugs": {
+    "web": "https://github.com/sass-mq/sass-mq/issues"
+  },
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/sass-mq/sass-mq.git"
+    }
+  ],
+  "licenses": [
+    {
+      "name": "MIT",
+      "url": "http://opensource.org/licenses/MIT"
+    }
+  ],
+  "homepage": "http://sass-mq.github.io/sass-mq/"
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,19 @@
     "queries",
     "media"
   ],
+  "ignore": [
+    "test",
+    "sassdoc",
+    "**/.*",
+    "sache.json",
+    "sassdoc.sh",
+    "test.sh"
+  ],
+  "files": [
+    "_mq.scss",
+    "LICENSE.md",
+    "README.md"
+  ],
   "contributors": [
     {
       "name": "Guardian Media Group and Contributors.",


### PR DESCRIPTION
By popular demand…

Adds the ability to install sass-mq using npm (but doesn't necessarily means we have to add it to the npm registry, although with Travis we could automate that).

Fixes #22 and #51 

@meza in the mean time, please use `npm install "sass-mq/sass-mq#npm-support" --save` to install sass-mq using npm.

![ ](http://www.gifbin.com/bin/062015/1433522088_bear_catches_piece_of_bread.gif)