### PR TITLE
add orientation to currently active breakpoint display

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ OR:
     // If you want to display the currently active breakpoint in the top
     // right corner of your site during development, add the breakpoints
     // to this list, ordered by width, e.g. (mobile, tablet, desktop).
+    // If you append to end of your breakpoint name _L or _P,orientation
+    // will be capture aswell, e.g. (mobile_P, mobile_L, tablet_P).
     $mq-show-breakpoints: (mobile, mobileLandscape, tablet, desktop, wide);
 
     @import 'path/to/mq';

--- a/_mq.scss
+++ b/_mq.scss
@@ -268,7 +268,18 @@ $mq-media-type: all !default;
         // Loop through the breakpoints that should be shown
         @each $show-breakpoint in $show-breakpoints {
             $width: mq-get-breakpoint-width($show-breakpoint, $breakpoints);
-            @include mq($show-breakpoint, $breakpoints: $breakpoints) {
+
+            //Check if orientation is define
+            $orientation: false;
+            @if(str-index(str-slice(to-upper-case($show-breakpoint),-1), "P") != null){
+                $orientation: '(orientation: portrait)';
+            }@else{
+                @if( str-index(str-slice(to-upper-case($show-breakpoint),-1), "L") != null){
+                    $orientation: '(orientation: landscape)'
+                }
+            }
+            
+            @include mq($show-breakpoint, $breakpoints: $breakpoints, $and: $orientation) {
                 content: "#{$show-breakpoint} ≥ #{$width} (#{mq-px2em($width)})";
             }
         }


### PR DESCRIPTION
This is a clean way to show active breakpoint display if you are working with orientation.

Aswell, i recommend the use of this mixins:
```sass
//Tablet portrait
@mixin tablet-portrait{
	@include mq($from: tablet_P, $and: '(orientation: portrait)'){
		@content
	}
}

//Tablet landscape
@mixin tablet-landscape{
	@include mq($from: tablet_L, $and: '(orientation: landscape)'){
		@content
	}
}

//Mobile portrait
@mixin mobile-portrait{
	@include mq($from: mobile_P, $and: '(orientation: portrait)'){
		@content
	}
}

//Mobile landscape
@mixin mobile-landscape{
	@include mq($from: mobile_L, $and: '(orientation: landscape)'){
		@content
	}
}
```
e.g.
```sass
.forge{
     color:blue; 
     @include mobile-portrait(){
      color:red;
     }
    @include mobile-landscape(){
      color:green;
    }
}

 