### PR TITLE
Don’t rasterize print queries when non-responsive

### DIFF
--- a/_mq.scss
+++ b/_mq.scss
@@ -205,6 +205,7 @@ $mq-media-type: all !default;
             and (
                 $until == false or $max-width >= $target-width
             )
+            and $media-type != 'print'
         ) {
             @content;
         }

--- a/test/_after-import.scss
+++ b/test/_after-import.scss
@@ -135,6 +135,16 @@ $mq-static-breakpoint: desktop;
     }
 }
 
+/* Do not rasterize print media queries into when $mq-responsive is false */
+$mq-responsive: false;
+$mq-media-type: all;
+
+@include mq($media-type: 'print') {
+    .print:after {
+        content: "Should not appear, because print style only";
+    }
+}
+
 /* Only style screen media type */
 $mq-responsive: true;
 $mq-media-type: screen;

--- a/test/output/dart-sass.log
+++ b/test/output/dart-sass.log
@@ -4,33 +4,39 @@ WARNING: Assuming 640 to be in pixels, attempting to convert it into pixels.
     test/_after-import.scss 17:5   styles()
     test/_after-import.scss 117:5  @import
     test/test.scss 6:9             root stylesheet
+
 WARNING: Assuming 768 to be in pixels, attempting to convert it into pixels.
     _mq.scss 90:9                  mq-px2em()
     _mq.scss 180:25                mq()
     test/_after-import.scss 37:5   styles()
     test/_after-import.scss 117:5  @import
     test/test.scss 6:9             root stylesheet
+
 WARNING: Assuming 1023 to be in pixels, attempting to convert it into pixels.
     _mq.scss 90:9                  mq-px2em()
     _mq.scss 189:25                mq()
     test/_after-import.scss 37:5   styles()
     test/_after-import.scss 117:5  @import
     test/test.scss 6:9             root stylesheet
+
 WARNING: Assuming 640 to be in pixels, attempting to convert it into pixels.
     _mq.scss 90:9                  mq-px2em()
     _mq.scss 180:25                mq()
     test/_after-import.scss 17:5   styles()
     test/_after-import.scss 126:5  @import
     test/test.scss 6:9             root stylesheet
+
 WARNING: Assuming 768 to be in pixels, attempting to convert it into pixels.
     _mq.scss 90:9                  mq-px2em()
     _mq.scss 180:25                mq()
     test/_after-import.scss 37:5   styles()
     test/_after-import.scss 126:5  @import
     test/test.scss 6:9             root stylesheet
+
 WARNING: Assuming 1023 to be in pixels, attempting to convert it into pixels.
     _mq.scss 90:9                  mq-px2em()
     _mq.scss 189:25                mq()
     test/_after-import.scss 37:5   styles()
     test/_after-import.scss 126:5  @import
     test/test.scss 6:9             root stylesheet
+

--- a/test/output/test-dart.css
+++ b/test/output/test-dart.css
@@ -195,6 +195,7 @@ body:before {
   content: "Static, forced to tablet";
 }
 
+/* Do not rasterize print media queries into when $mq-responsive is false */
 /* Only style screen media type */
 @media screen and (max-width: 19.99em) {
   body {

--- a/test/output/test-eyeglass.css
+++ b/test/output/test-eyeglass.css
@@ -133,6 +133,7 @@ body:before {
 .static-forced:after {
   content: "Static, forced to tablet"; }
 
+/* Do not rasterize print media queries into when $mq-responsive is false */
 /* Only style screen media type */
 @media screen and (max-width: 19.99em) {
   body {

--- a/test/output/test-node.css
+++ b/test/output/test-node.css
@@ -133,6 +133,7 @@ body:before {
 .static-forced:after {
   content: "Static, forced to tablet"; }
 
+/* Do not rasterize print media queries into when $mq-responsive is false */
 /* Only style screen media type */
 @media screen and (max-width: 19.99em) {
   body {

--- a/test/output/test-ruby.css
+++ b/test/output/test-ruby.css
@@ -133,6 +133,7 @@ body:before {
 .static-forced:after {
   content: "Static, forced to tablet"; }
 
+/* Do not rasterize print media queries into when $mq-responsive is false */
 /* Only style screen media type */
 @media screen and (max-width: 19.99em) {
   body {


### PR DESCRIPTION
We've found that when generating IE8 specific stylesheet with `$mq-responsive` is set to false, any print-specific styles were also being rasterized into the screen styles.

The control flow when `$mq-responsive` is `false` does not currently consider the `$media-type` at all. This adds a relatively naive check to make sure that `$mq-type` is not equal to `'print'`. For a fully robust solution other media types might need to be considered, but this solves our immediate problem.

I am not sure why the whitespace in `dart-sass.log` has changed – but as it's just a whitespace change I committed it anyway. I assume it's a change in a dependency somewhere.