### PR TITLE
Remove Node 4 tests, add Node 11 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
   - "9"
   - "10"
+  - "11"
 before_install:
   - rvm install 2.2.2
   - npm i npx


### PR DESCRIPTION
It's 2019 and it now seems reasonable to remove tests for Node 4.

For most people, Sass MQ should work with Node 4 (it's just Sass), but [eyeglass tests are failing](https://travis-ci.org/sass-mq/sass-mq/jobs/481834674).

This also adds tests for Node 11.