### PR TITLE
Basic container query support

### DIFF
--- a/_mq.scss
+++ b/_mq.scss
@@ -134,7 +134,8 @@ $media-type: all !default;
   $until: false,
   $and: false,
   $media-type: $media-type,
-  $breakpoints: $breakpoints
+  $breakpoints: $breakpoints,
+  $container: false
 ) {
   $min-width: 0;
   $max-width: 0;
@@ -143,7 +144,11 @@ $media-type: all !default;
   // From: this breakpoint (inclusive)
   @if $from {
     @if type-of($from) == number {
-      $min-width: px2em($from);
+      @if $container == false {
+        $min-width: px2em($from);
+      } @else {
+        $min-width: $from;
+      }
     } @else {
       $min-width: px2em(get-breakpoint-width($from, $breakpoints));
     }
@@ -152,7 +157,11 @@ $media-type: all !default;
   // Until: that breakpoint (exclusive)
   @if $until {
     @if type-of($until) == number {
-      $max-width: px2em($until);
+      @if $container == false {
+        $max-width: px2em($until);
+      } @else {
+        $max-width: $until;
+      }
     } @else {
       $max-width: px2em(get-breakpoint-width($until, $breakpoints)) - 0.01em;
     }
@@ -174,8 +183,14 @@ $media-type: all !default;
     $media-query: str-slice(unquote($media-query), 6);
   }
 
-  @media #{$media-type + $media-query} {
-    @content;
+  @if $container == false {
+    @media #{$media-type + $media-query} {
+      @content;
+    }
+  } @else {
+    @container #{$media-type + $media-query} {
+      @content;
+    }
   }
 }
 


### PR DESCRIPTION
Perhaps this is out of scope of this library, but it would be lovely to have some kind of container query support in sass-mq. Use it exclusively and have for years, so would be awesome to not have to use `@container` syntax directly just like I don't have to with `@media`.

There's loads more syntax to be explored should there be an interest in supporting them fully, especially around things like: Do we apply `container-type` automatically somehow? Do we support style queries?

Anyway, this is a really basic implementation that allows rudimentary usage:

```sass
.card {
    container-type: inline-size;

    @include mq($until: 400px, $container: true) {
        &__image {
            // Some stlyes
        }
    }
}
```

or 


```sass
.card {
    container-type: inline-size;

     &__image {
        @include mq($until: 400px, $container: true) {
            // Some stlyes
        }
    }
}
```